### PR TITLE
New: Allow moving backwards in combat

### DIFF
--- a/dmtoolkit/inittracker/static/tracker.js
+++ b/dmtoolkit/inittracker/static/tracker.js
@@ -8,6 +8,17 @@ function nextCombatant() {
     current.removeClass("selected");
 }
 
+function prevCombatant() {
+    current = $("tr.selected");
+    next = current.prev();
+    if (next.attr("id") == "tracker-header") {
+        // Don't want to select header row, so just go back another space
+        next = $("table#turntracker").children().eq(0).children().last();
+    }
+    next.addClass("selected");
+    current.removeClass("selected");
+}
+
 function sortInitiativeTable() {
     table = $('#turntracker');
     rows = table.find('tr:gt(0)').toArray().sort(compareRows).reverse();

--- a/dmtoolkit/inittracker/templates/tracker.jinja2
+++ b/dmtoolkit/inittracker/templates/tracker.jinja2
@@ -56,7 +56,7 @@
             </div>
 
             <table id="turntracker" class="w3-table w3-bordered w3-border">
-                <tr>
+                <tr id="tracker-header">
                     <th></th>
                     <th>Name</th>
                     <th>AC</th>
@@ -69,7 +69,10 @@
                 <button id="prompt-save-encounter-btn" class="w3-button w3-white w3-border w3-ripple">Save Encounter</button>
                 <button class="w3-button w3-white w3-border w3-ripple" onclick="rollInitiative()">Roll Initiative</button>
                 <button class="w3-button w3-white w3-border w3-ripple" onclick="sortInitiativeTable()">Order</button>
-                <button class="w3-button w3-white w3-border w3-ripple" onclick="nextCombatant()">Next Turn</button>
+                <div style="display: inline-flex">
+                    <button class="w3-button w3-white w3-border w3-ripple" onclick="prevCombatant()"><i class="fa-solid fa-arrow-left"></i></button>
+                    <button class="w3-button w3-white w3-border w3-ripple" onclick="nextCombatant()" style="border-left: 0 !important"><i class="fa-solid fa-arrow-right"></i></button>
+                </div>
             </div>
             <div>
                 <h3>Encounter Stats</h3>

--- a/dmtoolkit/templates/base.jinja2
+++ b/dmtoolkit/templates/base.jinja2
@@ -6,6 +6,7 @@
         <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
         <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+        <script src="https://kit.fontawesome.com/997e16441a.js" crossorigin="anonymous"></script>
         <script type="text/javascript">
             var csrf_token = "{{ csrf_token() }}";
 


### PR DESCRIPTION
# Summary

This PR replaces the "next" button on the turn tracker with two buttons: `<-` and `->`, which allow you to move combat forward a turn _and_ backward a turn.

# Changes

* replace `next` button with 2 arrow buttons
* add `prevCombatant` javascript function
* add fontawesome import to front end