### PR TITLE
Fix: Prevent update player form from failing due to name already being used

### DIFF
--- a/dmtoolkit/players/templates/edit_player.jinja2
+++ b/dmtoolkit/players/templates/edit_player.jinja2
@@ -14,6 +14,14 @@
             <fieldset>
                 {{ form.name.label }}
                 {{ form.name(value=player.name) }}
+                <br/>
+                {% if form.name.errors %}
+                    <ul class="errors">
+                        {% for error in form.name.errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
             </fieldset>
         </div>
         <div style="display: flex; flex-direction: row; justify-content: space-between">


### PR DESCRIPTION
The form validation logic which checks if a name is in use when creating a new character was also copied over to the update player form. This is problematic because when updating an existing player, that player's name will always be in the player base, meaning only updates which changed the player's name to a wholly unique value were allowed.

This PR amended the update form logic to pass validation if the name in the form is the same as the original name of the player. It also fixes some issues with error displaying in the update player form.