### PR TITLE
Feature: Add some default values for cookie-stored properties

### DIFF
--- a/dmtoolkit/api/encounters.py
+++ b/dmtoolkit/api/encounters.py
@@ -5,9 +5,17 @@ from uuid import uuid4
 
 from flask import request, Response
 
+DEFAULT_ENCOUNTERS = {
+    "sample1": {
+        "title": "(Sample) Bandits",
+        "desc": "A group of bandits ambushes the party.",
+        "monsters": ["Bandit-MM", "Bandit-MM", "Bandit-MM", "Bandit Captain-MM"]
+    }
+}
+
 def getall():
     """Return all encounters."""
-    return json.loads(request.cookies.get("encounters", "{}"))
+    return json.loads(request.cookies.get("encounters", "{}")) or DEFAULT_ENCOUNTERS
 
 
 def get(eid: str):

--- a/dmtoolkit/api/players.py
+++ b/dmtoolkit/api/players.py
@@ -10,8 +10,23 @@ DATA_DIR = Path(__file__).parent / "data"
 
 PLAYERS: list = []
 
+SAMPLE_PLAYERS = [
+    Player(
+        name="(Sample) Aragorn",
+        hp=12,
+        ac=14,
+        pp=12,
+        race_id="Human",
+        class_id="Ranger",
+        subclass_id="Horizon Walker",
+        level=1,
+        enabled=True,
+        notes=""
+    ),
+]
+
 def list_players() -> list[Player]:
-   return load_json_string(request.cookies.get("players", "[]"))
+   return load_json_string(request.cookies.get("players", "[]")) or SAMPLE_PLAYERS
 
 def get_player(player_name: str) -> Player | None:
     for player in list_players():


### PR DESCRIPTION
Players and encounters are stored in cookies now. If the cache is empty, rather than display no encounters or players, we have some example resources now.