### PR TITLE
Allow tagging players

### DIFF
--- a/dmtoolkit/__init__.py
+++ b/dmtoolkit/__init__.py
@@ -12,6 +12,8 @@ def init_app():
     app = Flask(__name__, instance_relative_config=False)
     app.config.from_object("config.DevConfig")
 
+    app.jinja_env.lstrip_blocks = True # Prevent weird indents from templates
+
     csrf.init_app(app)
     # session.init_app(app)
 

--- a/dmtoolkit/api/models.py
+++ b/dmtoolkit/api/models.py
@@ -757,6 +757,8 @@ class Player:
     enabled: bool = False
     notes: str = ""
 
+    tags: list[str] = field(default_factory=list)
+
 @dataclass
 class Class:
     name: str

--- a/dmtoolkit/api/players.py
+++ b/dmtoolkit/api/players.py
@@ -28,6 +28,13 @@ SAMPLE_PLAYERS = [
 def list_players() -> list[Player]:
    return load_json_string(request.cookies.get("players", "[]")) or SAMPLE_PLAYERS
 
+def list_player_tags() -> list[str]:
+    """Return all tags currently in use."""
+    tags = set()
+    for player in list_players():
+        tags |= set(player.tags)
+    return list(tags)
+
 def get_player(player_name: str) -> Player | None:
     for player in list_players():
         if player.name == player_name:

--- a/dmtoolkit/inittracker/routes.py
+++ b/dmtoolkit/inittracker/routes.py
@@ -9,7 +9,7 @@ from dmtoolkit.api.conditions import get_condition
 from dmtoolkit.api.items import get_item
 from dmtoolkit.api.models import Item
 from dmtoolkit.api.monsters import get_monster, get_monster_names
-from dmtoolkit.api.players import list_players, get_player
+from dmtoolkit.api.players import list_players, get_player, list_player_tags
 from dmtoolkit.api.races import get_race
 from dmtoolkit.api.spells import get_spell
 from dmtoolkit.inittracker.loot import loot as generate_loot
@@ -38,7 +38,8 @@ def tracker():
         page = page,
         monsters = monsters,
         players = list_players(),
-        monster = monster
+        monster = monster,
+        player_tags = list_player_tags()
     )
 
 @tracker_bp.route("/api/monsters", methods=["GET"])

--- a/dmtoolkit/inittracker/templates/add-player.jinja2
+++ b/dmtoolkit/inittracker/templates/add-player.jinja2
@@ -1,10 +1,47 @@
 {% from "modal.jinja2" import render_modal %}
 
-{% call render_modal("player-add-modal") %}
+{% call render_modal("player-add-modal", "Add Player to Combat") %}
+    <div style="display: flex; justify-content: space-between; margin-top: 1em;">
+        <button class="w3-button w3-red" id="player-add-all-btn">Add All</button>
+        <span>
+            Filter by Tag:
+            <select class="w3-select" style="width: 20em" name="tag-filter" id="tag-filter">
+                <option value=""><em>Show All Players</em></option>
+                {% for tag in player_tags %}
+                    <option value="{{ tag }}">{{ tag }}</option>
+                {% endfor %}
+            </select>
+        </span>
+    </div>
     {%- for player in players %}
-        <div class="_player-row w3-container w3-cell-row w3-padding">
+        <div class="_player-row w3-container w3-cell-row w3-padding" data-tags="{{ player.tags | tojson | forceescape }}">
             <span class="w3-large w3-cell w3-cell-middle">{{ player.name }}</span>
-            <button class="w3-button w3-ripple" style="float: right">Add Player</button>
+            <button class="w3-button w3-ripple _player-add-btn" style="float: right">Add Player</button>
         </div>
     {% endfor %}
+
+    <script>
+        $("#tag-filter").change(function () {
+            tag = $("#tag-filter").val();
+            $("div._player-row").each(function() {
+                if (tag == "" || $(this).data("tags").includes(tag)) {
+                    $(this).show();
+                }
+                else {
+                    $(this).hide();
+                }
+            });
+        });
+
+        $("#player-add-all-btn").click(function() {
+            $('#player-add-modal').find('._player-add-btn').each(function () {
+                if (!$(this).is(":visible")) {
+                    return; // Works like 'continue' in Python apparently
+                };
+                if ($(this).text() == "Add Player") {
+                    $(this).trigger("click");
+                }
+            });
+        })
+</script>
 {% endcall %}

--- a/dmtoolkit/inittracker/templates/tracker.jinja2
+++ b/dmtoolkit/inittracker/templates/tracker.jinja2
@@ -138,7 +138,7 @@
     });
     $('#monstersearch').focus(function () { $(this).val(''); });
     $('#manage-players-btn').click(function() { $('#player-add-modal').show(); updateAddPlayerButtons();});
-    $('#player-add-modal').find('button').click(function() { togglePlayer($(this)) });
+    $('#player-add-modal').find('._player-add-btn').click(function() { togglePlayer($(this)) });
 
     // Save Encounter
     $('#prompt-save-encounter-btn').click(function() { $('#save-encounter-modal').show(); });

--- a/dmtoolkit/players/routes.py
+++ b/dmtoolkit/players/routes.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+import json
 
 from flask import Blueprint, render_template, redirect, url_for, make_response
 from flask_wtf import FlaskForm
@@ -8,6 +9,7 @@ from wtforms.validators import InputRequired, NumberRange, ValidationError
 import dmtoolkit.api.players as api
 from dmtoolkit.api.races import list_races
 from dmtoolkit.api.classes import list_classes, get_class
+from dmtoolkit.widgets import TagField
 
 players_bp = Blueprint(
     "players_bp",
@@ -27,6 +29,7 @@ class CreateForm(FlaskForm):
     class_ = SelectField("Class", choices=[(c.name, c.name) for c in list_classes()])
     level = IntegerField("Player Level", [InputRequired(), NumberRange(min=1)])
     subclass = SelectField("Subclass", choices=[], validate_choice=False)
+    tags = TagField("Tags", whitelist=["foo", "bar"])
     submit = SubmitField("Create Player Character")
 
     def validate_name(self, field):
@@ -72,7 +75,8 @@ def new_player_page():
             "race_id": form.race.data,
             "level": form.level.data,
             "class_id": form.class_.data or "",
-            "subclass_id": form.subclass.data or ""
+            "subclass_id": form.subclass.data or "",
+            "tags": [x.get("value") for x in json.loads(form.tags.data or "[])")]
         }
         resp = make_response(redirect(url_for("players_bp.list_players_page")))
         api.create_player(resp, player)
@@ -93,6 +97,8 @@ def update_player_page(player_name: str):
     if not player_arr:
         return "404 Player Not Found"
     player = player_arr[0]
+
+    print(player)
 
     if form.validate_on_submit():
         player_params = {}
@@ -115,6 +121,8 @@ def update_player_page(player_name: str):
             subclass_list = list(get_class(form.class_.data or player.class_id).subclasses)
             subclass = subclass_list[idx]
             player_params["subclass_id"] = subclass.name
+        if val := form.tags.data:
+            player_params["tags"] = [x.get("value") for x in json.loads(form.tags.data or "[])")]
         
         print(player_params)
 
@@ -130,14 +138,18 @@ def update_player_page(player_name: str):
         return resp
 
     form.class_.data = player.class_id
+    form.tags.set_tags(player.tags)
+    form.tags.whitelist = api.list_player_tags()
     if player.class_id:
         form.subclass.choices = [(str(x), y) for x, y in enumerate([c.name for c in get_class(player.class_id).subclasses])]
         if player.subclass_id.isdigit():
             # Previous bug wrote the index of the subclass in the list as the subclass_id; this 
             #   fix allows those older saved characters to be loaded correctly in most cases.
             idx = int(player.subclass_id)
-        else:
+        elif player.subclass_id in {x[1] for x in form.subclass.choices}:
             idx = list(x[1] for x in form.subclass.choices).index(player.subclass_id)
+        else:
+            idx = 0 # fallback
         form.subclass.data = str(idx)
     
     page = {

--- a/dmtoolkit/players/routes.py
+++ b/dmtoolkit/players/routes.py
@@ -60,7 +60,7 @@ def list_players_page():
         "title": "DMTTools - Players"
     }
     players = api.list_players()
-    return render_template("list_players.jinja2", page=page, players=players)
+    return render_template("list_players.jinja2", page=page, players=players, all_tags=api.list_player_tags())
 
 
 @players_bp.route("/new", methods=["GET", "POST"])

--- a/dmtoolkit/players/templates/edit_player.jinja2
+++ b/dmtoolkit/players/templates/edit_player.jinja2
@@ -103,7 +103,15 @@
                 {% endif %}
             </fieldset>
         </div>
-        {{ form.submit }}
+        <div style="display: flex; flex-direction: row; justify-content: space-between">
+            <fieldset style="display: flex; flex-grow: 1; gap: 10px;">
+                {{ form.tags.label }} {{ form.tags(style="flex-grow: 1") }}
+            </fieldset>
+
+            <fieldset>
+                {{ form.submit }}
+            </fieldset>
+        </div>
     </form>
 </div>
 

--- a/dmtoolkit/players/templates/edit_player.jinja2
+++ b/dmtoolkit/players/templates/edit_player.jinja2
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div style="width: 1200px; margin: auto">
+<div class="content">
     <h1>Edit {{ player.name }}</h1>
 
     <form method="POST" action="{{ url_for('players_bp.update_player_page', player_name=player.name) }}">

--- a/dmtoolkit/players/templates/list_players.jinja2
+++ b/dmtoolkit/players/templates/list_players.jinja2
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-<div style="width: 1200px; margin: auto">
+<div class="content">
     <h1>Player Characters</h1>
     <div class="w3-margin-bottom">
         <a href="{{ url_for('players_bp.new_player_page') }}" class="w3-button w3-white w3-border w3-ripple">Create New Player Character</a>
@@ -29,6 +29,9 @@
                 </div>
                 <div class="w3-padding">
                     <strong>Race: </strong> {{ player.race_id or "Unknown" }}
+                </div>
+                <div class="w3-padding">
+                    <strong>Tags: </strong> {% for tag in player.tags %}<span style="padding: 4px 10px; margin-right: 2px; border-radius: 16px;" class="w3-blue">{{ tag }}</span>{% endfor %}
                 </div>
             </div>
         </div>

--- a/dmtoolkit/players/templates/list_players.jinja2
+++ b/dmtoolkit/players/templates/list_players.jinja2
@@ -7,11 +7,20 @@
 {% block content %}
 <div class="content">
     <h1>Player Characters</h1>
-    <div class="w3-margin-bottom">
+    <div class="w3-margin-bottom" style="display: flex; justify-content: space-between;">
         <a href="{{ url_for('players_bp.new_player_page') }}" class="w3-button w3-white w3-border w3-ripple">Create New Player Character</a>
+        <span>
+            Filter by Tag:
+            <select class="w3-select" style="width: 20em" name="tag-filter" id="tag-filter">
+                <option value=""><em>Show All Players</em></option>
+                {% for tag in all_tags %}
+                    <option value="{{ tag }}">{{ tag }}</option>
+                {% endfor %}
+            </select>
+        </span>
     </div>
     {% for player in players %}
-        <div class="w3-card w3-padding" style="margin-bottom: 12px">
+        <div class="w3-card w3-padding _player" style="margin-bottom: 12px" data-tags="{{ player.tags | tojson | forceescape }}">
             <div>
                 <span class="w3-xlarge">{{ player.name }}</span>
                 <a href="{{ url_for('players_bp.delete_player', player_name=player.name)}}" style="float: right" class="w3-button w3-white w3-border w3-ripple">Delete</a>
@@ -37,4 +46,18 @@
         </div>
     {% endfor %}
 </div>
+
+<script>
+    $("#tag-filter").change(function () {
+        tag = $("#tag-filter").val();
+        $("div._player").each(function() {
+            if (tag == "" || $(this).data("tags").includes(tag)) {
+                $(this).show();
+            }
+            else {
+                $(this).hide();
+            }
+        })
+    })
+</script>
 {% endblock %}

--- a/dmtoolkit/players/templates/new_player.jinja2
+++ b/dmtoolkit/players/templates/new_player.jinja2
@@ -103,7 +103,15 @@
                 {% endif %}
             </fieldset>
         </div>
-        {{ form.submit }}
+        <div style="display: flex; flex-direction: row; justify-content: space-between">
+            <fieldset style="display: flex; flex-grow: 1; gap: 10px;">
+                {{ form.tags.label }} {{ form.tags(style="flex-grow: 1") }}
+            </fieldset>
+
+            <fieldset>
+                {{ form.submit }}
+            </fieldset>
+        </div>
     </form>
 </div>
 

--- a/dmtoolkit/players/templates/new_player.jinja2
+++ b/dmtoolkit/players/templates/new_player.jinja2
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div style="width: 1200px; margin: auto">
+<div class="content">
     <h1>Create New Player Character</h1>
 
     <form method="POST" action="{{ url_for('players_bp.new_player_page') }}">

--- a/dmtoolkit/settings/templates/settings.jinja2
+++ b/dmtoolkit/settings/templates/settings.jinja2
@@ -5,8 +5,7 @@
 {% endblock %}
 
 {% block content %}
-
-<div style="width: 1200px; margin: auto">
+<div class="content">
     <h1>Options</h1>
 
     <form method="POST" action="">
@@ -40,10 +39,10 @@
                     </div>
                 </fieldset>
             {% endfor %}
+        </div>
 
         {{ form.submit(class_="w3-button w3-white w3-border w3-ripple") }}
     </form>
 </div>
-<br/>
 
 {% endblock %}

--- a/dmtoolkit/static/aux.css
+++ b/dmtoolkit/static/aux.css
@@ -28,5 +28,14 @@
     background-color: #ffbb55  !important;
     color: #774801   !important;
     border: 1px solid #774801   !important;
-;
+}
+
+body {
+    min-height: 100dvh;
+}
+
+div.content {
+    width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
 }

--- a/dmtoolkit/templates/base.jinja2
+++ b/dmtoolkit/templates/base.jinja2
@@ -34,7 +34,7 @@
         {% block header %}{% endblock %}
     </head>
     <body>
-        <div style="display: flex; flex-direction: column">
+        <div style="display: flex; flex-direction: column; min-height: 100dvh;">
             <div class="w3-bar w3-border w3-light-grey">
                 <a class="w3-bar-item w3-button" href="{{ url_for('settings_bp.settings') }}"><i class="fa-solid fa-gear"></i></a>
                 <a class="w3-bar-item w3-button" href="{{ url_for('tracker_bp.tracker') }}">Tracker</a>
@@ -59,7 +59,7 @@
                 {% endif %}
             {% endwith %}
 
-            <div id="content" class="content" style="flex-grow:1;display: flex;flex-direction: column;">
+            <div id="content" class="content" style="flex-grow:1; display: flex; flex-direction: column;">
                 {% block content %}{% endblock %}
             </div>
 

--- a/dmtoolkit/templates/base.jinja2
+++ b/dmtoolkit/templates/base.jinja2
@@ -8,6 +8,9 @@
         <link rel=stylesheet type="text/css" href="{{ url_for('static', filename='aux.css') }}">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
         <script src="https://kit.fontawesome.com/997e16441a.js" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify@4.38.0"></script>
+        <link href="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.css" rel="stylesheet" type="text/css" />
+
         <script type="text/javascript">
             var csrf_token = "{{ csrf_token() }}";
 
@@ -64,5 +67,14 @@
                 <p>Ben Airey, <script>document.write(new Date().getFullYear())</script><span style="margin-left: 15px; margin-right: 15px">|</span><a href="https://github.com/ben-githubs/dmtoolkit/issues/new">Report an Issue</a></p>
             </footer>
         </div>
+
+        <script>
+            $(document).ready(function() {
+                $(".tagify").each(function(_, elem) {
+                    var tagify = new Tagify(elem, {whitelist: $(elem).data('tags')});
+                    tagify.addTags($(elem).data("value"));
+                })
+            })
+        </script>
     </body>
 </html>

--- a/dmtoolkit/widgets.py
+++ b/dmtoolkit/widgets.py
@@ -10,8 +10,16 @@ class TagField(StringField):
     def __call__(self, **kwargs):
         kwargs["class"] = "tagify"
         kwargs["data-tags"] = json.dumps(self.whitelist)
-        kwargs["data-value"] = json.dumps([{"value": "superman"}, {"value": "batman"}])
         return super(TagField, self).__call__(**kwargs)
 
     # Find a hook to transform the form data from a json object to a list of strings
     # This is so that you can set the original tags easily, and so we can parse the vals when validating the form
+    def get_tags(self):
+        """Easy way to get the tags."""
+        # The form data is serialized as '[{"value": x}, {"value": y}]
+        return [x["value"] for x in json.loads(self.data or "[]")]
+
+    def set_tags(self, tags: list[str]):
+        """Easy way to set the tags."""
+        self.data = json.dumps([{"value": x} for x in tags])
+        print(self.data)

--- a/dmtoolkit/widgets.py
+++ b/dmtoolkit/widgets.py
@@ -1,0 +1,17 @@
+import json
+from typing import Optional
+from wtforms import StringField
+
+class TagField(StringField):
+    def __init__(self, *args, whitelist: Optional[list[str]] = None, **kwargs):
+        super(TagField, self).__init__(*args, **kwargs)
+        self.whitelist = whitelist or []
+
+    def __call__(self, **kwargs):
+        kwargs["class"] = "tagify"
+        kwargs["data-tags"] = json.dumps(self.whitelist)
+        kwargs["data-value"] = json.dumps([{"value": "superman"}, {"value": "batman"}])
+        return super(TagField, self).__call__(**kwargs)
+
+    # Find a hook to transform the form data from a json object to a list of strings
+    # This is so that you can set the original tags easily, and so we can parse the vals when validating the form


### PR DESCRIPTION
## Summary

Lets users give arbitrary tags to players (many-to-many) to better organize their games. Users can filter by these tags when listing players or adding them to combat. Resolves #39.

## Details

- Added a new HTML form widget for free-text tags
- Added tag field to player model
- Added rendering for tags on the "list players" page
- Added ability to add and remove tags
- Added ability to get list of all currently in-use tags (so pages can display tag values to filter by)
- Users can now filter the list of players in the "add player" modal to only those with a certain tag, and also use an "add all" button to add them all quickly

## Screenshots
<img width="617" height="364" alt="image" src="https://github.com/user-attachments/assets/31c78dfc-9db7-4fe6-b47e-abd0687335ff" />

**Fig 1:** Adding a tag to a player.

<img width="1277" height="374" alt="image" src="https://github.com/user-attachments/assets/7e632a8e-7665-4d65-9a9b-ef66c0887587" />

**Fig 2:** See how players are tagged. Notice that you can have more than one tag per player.

<img width="1047" height="368" alt="image" src="https://github.com/user-attachments/assets/34c8b481-cb99-4d82-995c-9e35cc29a859" />

**Fig 3:** Filter players by tag when adding to combat. Use the "Add All" button to add all currently-presented players.
