### PR TITLE
Add Round Counter

### DIFF
--- a/dmtoolkit/inittracker/static/tracker.js
+++ b/dmtoolkit/inittracker/static/tracker.js
@@ -1,3 +1,17 @@
+
+const GameMaster = {
+    roundCounter: 1, // How many rounds of combat have passed?
+
+    newRound: function() {
+        this.roundCounter = 1;
+        this.conditions = [];
+    },
+    incrementRound: function(amt) {
+        this.roundCounter += amt;
+        console.log(`Round: ${this.roundCounter}`);
+    }
+}
+
 function nextCombatant() {
     cycleCombatants(1);
 }
@@ -20,12 +34,14 @@ function cycleCombatants(step) {
                 // Loop to bottom if needed
                 if (next.attr("id") == "tracker-header") {
                     next = $("table#turntracker").children().eq(0).children().last();
+                    GameMaster.incrementRound(-1);
                 }
             } else {
                 next = next.next();
                 // Loop back to top if needed
                 if (next.length == 0) {
                     next = $("table#turntracker").children().eq(0).children().eq(1);
+                    GameMaster.incrementRound(1);
                 }
             }
         } while (nRetries < combatants.length && (next.data("type") == "npc" && next.data("dead") == true))

--- a/dmtoolkit/inittracker/templates/add-status.jinja2
+++ b/dmtoolkit/inittracker/templates/add-status.jinja2
@@ -69,12 +69,13 @@
             <option value="warding-bond">Warding Bond</option>
         </datalist>
 
-        <label>Expires: </label>
+        {# Removing for now; we need a proper object-orientated combat tracker for this to be feasible #}
+        {# <label>Expires: </label>
         <select id="status-search" class="w3-select" style="width: 100px;" value="never">
             <option value="never">Never</option>
             <option value="start">Start of Next Turn</option>
             <option value="end">End of Next Turn</option>
-        </select>
+        </select> #}
 
         <button id="modal-add-status-button" class="w3-button w3-white w3-ripple" style="width: 150px;">Add Status</button>
     </div>


### PR DESCRIPTION
## Summary

Added some internal logic to track round number. This has no benefits now but it lays the groundwork to have automations run, like removing status effects after X rounds.

Also I removed the button that let you specify a status should be removed after X rounds, because it was never implemented 🙃

## Details

- Created a "GameMaster" object which tracks global initiative data
- Removed "Remove after..." button when adding a status