### PR TITLE
Fix: Add All players using wrong statblocks

### DIFF
--- a/dmtoolkit/inittracker/static/tracker.js
+++ b/dmtoolkit/inittracker/static/tracker.js
@@ -207,6 +207,7 @@ function togglePlayer(button) {
             url: `/api/players/${playerName}`,
             method: 'GET',
             success: function(response) {
+                console.log(`${playerName}.player`);
                 tbody = $("#turntracker").children().eq(0);
                 trow = $("<tr></tr>");
                 data = $.parseJSON(response);
@@ -233,6 +234,7 @@ function togglePlayer(button) {
                 trow.data("type", "player");
 
                 trow.click(function(event) { updateStatblockTarget(event); });
+                console.log(`${playerName}.player`);
 
                 tbody.append(trow);
                 updateAddPlayerButtons();

--- a/dmtoolkit/inittracker/static/tracker.js
+++ b/dmtoolkit/inittracker/static/tracker.js
@@ -200,7 +200,7 @@ function addMonster(monsterId, params={}) {
     });
 }
 
-function togglePlayer(button) {
+function togglePlayer(button, playerName="") {
     playerName = button.prev().text();
     if (button.text() == "Add Player") {
         $.ajax({

--- a/dmtoolkit/inittracker/templates/add-player.jinja2
+++ b/dmtoolkit/inittracker/templates/add-player.jinja2
@@ -39,7 +39,8 @@
                     return; // Works like 'continue' in Python apparently
                 };
                 if ($(this).text() == "Add Player") {
-                    $(this).trigger("click");
+                    playerName = $(this).prev().text();
+                    togglePlayer($(this), playerName);
                 }
             });
         })


### PR DESCRIPTION
When clicking "Add All" to add players to the tracker, for some reason the tracker would display an entry for each player character, but they would all be linked to the same statblock when clicked. I think it has something to do with making multiple ajax calls in parallel and a race condition; I fixed it by explicitly passing the correct player ID to the calls instead of inferring it inside.